### PR TITLE
Make sure AAPL 10-Q is not always returned

### DIFF
--- a/sec_downloader/core.py
+++ b/sec_downloader/core.py
@@ -66,5 +66,5 @@ class Downloader:
         storage = DownloadStorage(filter_pattern=ONLY_HTML)
         with storage as path:
             dl = SecEdgarDownloader(self.company_name, self.email_address, path)
-            dl.get("10-Q", "AAPL", limit=1, download_details=True)
+            dl.get(doc_type, ticker, limit=1, download_details=True)
         return storage.get_file_contents()[0].content


### PR DESCRIPTION
Found that `doc_type` and `ticker` are not being passed down the line. Made sure they are passed down.